### PR TITLE
Add Bits Coop

### DIFF
--- a/_indies/bits.md
+++ b/_indies/bits.md
@@ -1,0 +1,15 @@
+---
+title: bits.coop
+homepage: https://bits.coop/
+business_models:
+- paid-development
+- paid-support
+layout: indie
+logo: /logos/bits.svg
+---
+
+Bits use deep expertise with WebGL, maps, P2P, data replication, and modular software architecture to deliver cutting-edge experiences.
+
+Bits works with clients in manufacturing, architecture, engineering, and non-profit sectors to integrate web technology into factories, professional tools, and remote field work.
+
+Bits are technologists and artists with decades of experience.  The give talks, facilitate workshops, publish free and open source software, and participate in open collaboration with the greater community.  They are always sharing what they know.


### PR DESCRIPTION
@mk30 @substack: If it's alright, I'd like to add bits.coop to indieopensource.com's list of indies. I think you're a particularly good example of paid development and paid support models.

I've started by adapting the text from the bits.coop homepage. It would also be nice to:

- [ ] add an SVG logo for bits to `/logos/bits.svg` --- I see you use the router graphic from your homepage on Twitter, but I couldn't find an easy way to get a static, vector version of it
- [ ] add one of you to `CODEOWNERS` for bits' data and logo files